### PR TITLE
[KlaudSol-CMS-#184] Important fix do not redirect api menus 89 to api menus donuts

### DIFF
--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -61,9 +61,14 @@ class Entity {
 
     static async findBySlug({entity_type_slug, slug}) {
       const db = new DB();
+       
+      function isNumber(str) {
+        return !isNaN(str);
+      }
 
-      console.log(entity_type_slug)
-      console.log(slug)
+     const propertyType = isNumber(slug) ? "longValue" : "stringValue" 
+     const conditionType = isNumber(slug) ? "entities.id" : "entities.slug";
+     
       const sql = `SELECT entities.id, entity_types.id, entity_types.name, entity_types.slug, entities.slug, 
                   attributes.name, attributes.type, attributes.\`order\`,
                   \`values\`.value_string, 
@@ -77,18 +82,18 @@ class Entity {
                   LEFT JOIN \`values\` ON values.entity_id = entities.id AND values.attribute_id = attributes.id
                   WHERE 
                       entity_types.slug = :entity_type_slug AND 
-                      entities.id = :slug
+                      ${conditionType} = :slug
                   ORDER BY attributes.\`order\` ASC
                   `;
                 
       const data = await db.executeStatement(sql, [
           {name: 'entity_type_slug', value:{stringValue: entity_type_slug}},
-          {name: 'slug', value:{longValue: slug}},
+          {name: 'slug', value:{[propertyType]: slug}},
       ]);
       
       return data.records.map(([
           {longValue: entity_type_id},
-          {longValue: slug},
+          {[propertyType]: slug},
           {stringValue: entity_type_name},
           {stringValue: entity_type_slug},
           {stringValue: entities_slug},

--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -1,15 +1,19 @@
 import DB from '@backend/data_access/DB';
-
+import { isNumber } from '@/components/Util';
 
 class Entity {
 
     static async findBySlugOrId({entity_type_slug, slug}) {
       const db = new DB();      
-     function isNumber(str) {
-        return !isNaN(str);
-      }
+      
+      // slug can be id # (number) or slugname (string)
+      // check the slug weather it consists numbers only in which return true, otherwise it will return false
+      
      const propertyType = isNumber(slug) ? "longValue" : "stringValue" 
-     const conditionType = isNumber(slug) ? "entities.id" : "entities.slug";
+     const conditionType = isNumber(slug) ? "entities.id" : "entities.slug"; 
+     
+     // if the type of slug is a number, propertyType and conditionType will be longValue and enitities.id respectively,
+     // and will be used for the query's condition WHERE and property name for "slug" in the map method
 
       const sql = `SELECT entities.id, entity_types.id, entity_types.name, entity_types.slug, entities.slug, 
                   attributes.name, attributes.type, attributes.\`order\`,

--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -62,6 +62,8 @@ class Entity {
     static async findBySlug({entity_type_slug, slug}) {
       const db = new DB();
 
+      console.log(entity_type_slug)
+      console.log(slug)
       const sql = `SELECT entities.id, entity_types.id, entity_types.name, entity_types.slug, entities.slug, 
                   attributes.name, attributes.type, attributes.\`order\`,
                   \`values\`.value_string, 
@@ -75,18 +77,18 @@ class Entity {
                   LEFT JOIN \`values\` ON values.entity_id = entities.id AND values.attribute_id = attributes.id
                   WHERE 
                       entity_types.slug = :entity_type_slug AND 
-                      entities.slug = :slug
+                      entities.id = :slug
                   ORDER BY attributes.\`order\` ASC
                   `;
                 
       const data = await db.executeStatement(sql, [
           {name: 'entity_type_slug', value:{stringValue: entity_type_slug}},
-          {name: 'slug', value:{stringValue: slug}},
+          {name: 'slug', value:{longValue: slug}},
       ]);
       
       return data.records.map(([
           {longValue: entity_type_id},
-          {stringValue: slug},
+          {longValue: slug},
           {stringValue: entity_type_name},
           {stringValue: entity_type_slug},
           {stringValue: entities_slug},

--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -3,72 +3,14 @@ import DB from '@backend/data_access/DB';
 
 class Entity {
 
-    static async find({entity_type_slug, id}) {
-      const db = new DB();
-
-      const sql = `SELECT entities.id, entity_types.id, entity_types.name, entity_types.slug, entities.slug, 
-                  attributes.name, attributes.type, attributes.\`order\`,
-                  \`values\`.value_string, 
-                  \`values\`.value_long_string, 
-                  \`values\`.value_integer, 
-                  \`values\`.value_datetime, 
-                  \`values\`.value_double                       
-                  FROM entities
-                  LEFT JOIN entity_types ON entities.entity_type_id = entity_types.id
-                  LEFT JOIN attributes ON attributes.entity_type_id = entity_types.id
-                  LEFT JOIN \`values\` ON values.entity_id = entities.id AND values.attribute_id = attributes.id
-                  WHERE 
-                      entity_types.slug = :entity_type_slug AND 
-                      entities.id = :id
-                  ORDER BY attributes.\`order\` ASC
-                  `;
-                
-      const data = await db.executeStatement(sql, [
-          {name: 'entity_type_slug', value:{stringValue: entity_type_slug}},
-          {name: 'id', value:{longValue: id}},
-      ]);
-      
-      return data.records.map(([
-          {longValue: id},
-          {longValue: entity_type_id},
-          {stringValue: entity_type_name},
-          {stringValue: entity_type_slug},
-          {stringValue: entities_slug},
-          {stringValue: attributes_name},
-          {stringValue: attributes_type},
-          {longValue: attributes_order},
-          {stringValue: value_string},
-          {stringValue: value_long_string},
-          {longValue: value_integer},
-          {stringValue: value_datetime},
-          {stringValue: value_double}
-        ]) => ({
-          id, 
-          entity_type_id,
-          entity_type_name, 
-          entity_type_slug, 
-          entities_slug, 
-          attributes_name, 
-          attributes_type, 
-          attributes_order, 
-          value_string,
-          value_long_string,
-          value_integer,
-          value_datetime,
-          value_double
-        })); 
-    }
-
-    static async findBySlug({entity_type_slug, slug}) {
-      const db = new DB();
-       
-      function isNumber(str) {
+    static async findBySlugOrId({entity_type_slug, slug}) {
+      const db = new DB();      
+     function isNumber(str) {
         return !isNaN(str);
       }
-
      const propertyType = isNumber(slug) ? "longValue" : "stringValue" 
      const conditionType = isNumber(slug) ? "entities.id" : "entities.slug";
-     
+
       const sql = `SELECT entities.id, entity_types.id, entity_types.name, entity_types.slug, entities.slug, 
                   attributes.name, attributes.type, attributes.\`order\`,
                   \`values\`.value_string, 

--- a/components/Util.js
+++ b/components/Util.js
@@ -67,6 +67,10 @@ export const useIndex = (array) => useMemo(() => (
   ),[array]);
 
 export const sortByOrderAsc = (first, second) => first[1].order - second[1].order; 
+
+export const isNumber = (str) => {
+  return !isNaN(str);
+}
   
 
 

--- a/pages/api/[entity_type_slug]/[id].js
+++ b/pages/api/[entity_type_slug]/[id].js
@@ -59,14 +59,14 @@ async function get(req, res) {
 
     // If user typed in the id instead of the slug
     // If slug is equal to one of the IDs, prioritize slug
-    if(parseInt(slug) && rawData.length === 0) {
-        const item = await Entity.find({entity_type_slug, id: slug});
+    // if(parseInt(slug) && rawData.length === 0) {
+    //     const item = await Entity.find({entity_type_slug, id: slug});
 
-        if(item.length !== 0) {
-            const itemSlug = item[0].entities_slug;
-            return res.redirect(`/api/${entity_type_slug}/${itemSlug}`);
-        }
-    }
+    //     if(item.length !== 0) {
+    //         const itemSlug = item[0].entities_slug;
+    //         return res.redirect(`/api/${entity_type_slug}/${itemSlug}`);
+    //     }
+    // }
 
     const initialFormat = {
       data: {},

--- a/pages/api/[entity_type_slug]/[id].js
+++ b/pages/api/[entity_type_slug]/[id].js
@@ -55,19 +55,9 @@ async function get(req, res) {
   try {
     const { entity_type_slug, id: slug } = req.query;
 
-    const rawData = await Entity.findBySlug({ entity_type_slug, slug });
+    const rawData = await Entity.findBySlugOrId({ entity_type_slug, slug });
 
-    // If user typed in the id instead of the slug
-    // If slug is equal to one of the IDs, prioritize slug
-    // if(parseInt(slug) && rawData.length === 0) {
-    //     const item = await Entity.find({entity_type_slug, id: slug});
-
-    //     if(item.length !== 0) {
-    //         const itemSlug = item[0].entities_slug;
-    //         return res.redirect(`/api/${entity_type_slug}/${itemSlug}`);
-    //     }
-    // }
-
+    
     const initialFormat = {
       data: {},
       metadata: {


### PR DESCRIPTION
1.  deleted the root cause of redirect as well as refactored the `findBySlug` and renamed it to `findBySlugOrId`.  

2. deleted the find() method since we can now use the `findBySlugOrId` as the replacement of  `.find` and `findBySlug` in the application code.
 
3. created a function that verifies weather the slug is only contains numbers, if true it will return `true`, otherwise it will return `false`.

4.  created a const `propertyType` and a `conditionType` for the query `WHERE` conditions and for the map method value named `slug` by applying computed property (es6 syntax).

note: this solution fixes (redirect problem) on issue #184 and (Allow access to contents using the slug) #107


![image1](https://user-images.githubusercontent.com/109654448/215398763-62515fda-6d63-4a9a-94f9-c9b13f928c15.PNG)
