### PR TITLE
[KlaudSol-CMS-#137] -Add pagination and page limit to tables

### DIFF
--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -39,7 +39,7 @@ class Entity {
       
       return data.records.map(([
           {longValue: entity_type_id},
-          {[propertyType]: slug},
+          {longValue: slug},
           {stringValue: entity_type_name},
           {stringValue: entity_type_slug},
           {stringValue: entities_slug},
@@ -121,6 +121,90 @@ class Entity {
           value_double
         })); 
   }
+
+  static async findByPageAndEntry({entity_type_slug , entry, page }) {
+    const db = new DB();
+     
+    let totalRows;
+    let totalOrders;
+    
+    const totalRowsSQL = `select COUNT(entities.id) 
+                          from entity_types LEFT JOIN entities ON entities.entity_type_id = entity_types.id 
+                          WHERE entity_types.slug = :entity_type_slug;
+                          `;
+
+    const totalRowsData = await db.executeStatement(totalRowsSQL,[
+      {name: 'entity_type_slug', value:{stringValue: entity_type_slug}},
+    ]);
+
+    [{longValue:totalRows}] = totalRowsData.records[0]
+
+    const totalOrdersSQL = `select COUNT(attributes.order)
+    from entity_types LEFT JOIN entities ON entities.entity_type_id = entity_types.id 
+    LEFT JOIN attributes ON attributes.entity_type_id = entity_types.id
+    WHERE entity_types.slug = :entity_type_slug`;
+
+    const totalOrdersData = await db.executeStatement(totalOrdersSQL,[
+      {name: 'entity_type_slug', value:{stringValue: entity_type_slug}},
+    ]);
+    [{longValue:totalOrders}] = totalOrdersData.records[0]
+    
+    let limit = entry ? (( totalOrders / totalRows ) * entry ) : 10;
+    let offset = page ? limit * page : 0
+
+    const sql = `SELECT entities.id, entity_types.id, entity_types.name, entity_types.slug, entities.slug, 
+                attributes.name, attributes.type, attributes.\`order\`,
+                \`values\`.value_string, 
+                \`values\`.value_long_string, 
+                \`values\`.value_integer, 
+                \`values\`.value_datetime, 
+                \`values\`.value_double                       
+                FROM entities
+                LEFT JOIN entity_types ON entities.entity_type_id = entity_types.id
+                LEFT JOIN attributes ON attributes.entity_type_id = entity_types.id
+                LEFT JOIN \`values\` ON values.entity_id = entities.id AND values.attribute_id = attributes.id
+                WHERE 
+                    entity_types.slug = :entity_type_slug  
+                ORDER BY entities.id, attributes.\`order\` ASC
+                LIMIT ${limit} OFFSET ${offset}
+                `;
+              
+    const dataRaw = await db.executeStatement(sql, [
+        {name: 'entity_type_slug', value:{stringValue: entity_type_slug}},
+    ]);
+       
+  const data = dataRaw.records.map(([
+        {longValue: id},
+        {longValue: entity_type_id},
+        {stringValue: entity_type_name},
+        {stringValue: entity_type_slug},
+        {stringValue: entities_slug},
+        {stringValue: attributes_name},
+        {stringValue: attributes_type},
+        {longValue: attributes_order},
+        {stringValue: value_string},
+        {stringValue: value_long_string},
+        {longValue: value_integer},
+        {stringValue: value_datetime},
+        {stringValue: value_double}
+      ]) => ({
+        id, 
+        entity_type_id,
+        entity_type_name, 
+        entity_type_slug, 
+        entities_slug, 
+        attributes_name, 
+        attributes_type, 
+        attributes_order, 
+        value_string,
+        value_long_string,
+        value_integer,
+        value_datetime,
+        value_double
+      })); 
+
+      return {total_rows:totalRows, data}
+}
 
     //Work in progress
     static async create({slug, entity_type_id, ...entry}) {

--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -128,7 +128,7 @@ class Entity {
     let totalRows;
     let totalOrders;
     
-    const totalRowsSQL = `select COUNT(entities.id) 
+    const totalRowsSQL = `SELECT COUNT(entities.id) 
                           from entity_types LEFT JOIN entities ON entities.entity_type_id = entity_types.id 
                           WHERE entity_types.slug = :entity_type_slug;
                           `;
@@ -139,7 +139,7 @@ class Entity {
 
     [{longValue:totalRows}] = totalRowsData.records[0]
 
-    const totalOrdersSQL = `select COUNT(attributes.order)
+    const totalOrdersSQL = `SELECT COUNT(attributes.order)
     from entity_types LEFT JOIN entities ON entities.entity_type_id = entity_types.id 
     LEFT JOIN attributes ON attributes.entity_type_id = entity_types.id
     WHERE entity_types.slug = :entity_type_slug`;

--- a/components/klaudsolcms/pagination/AppContentPagination.js
+++ b/components/klaudsolcms/pagination/AppContentPagination.js
@@ -1,0 +1,182 @@
+import React from "react";
+import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from "react-icons/md";
+import { AiOutlineDoubleLeft, AiOutlineDoubleRight } from "react-icons/ai";
+import AppButtonSpinner from '@/components/klaudsolcms/AppButtonSpinner';
+
+import {
+  SET_ENTRIES,
+  SET_PAGE,
+  PAGE_SETS_RENDERER,
+} from "@/lib/actions";
+
+const AppContentPagination = ({
+  dispatch, 
+  defaultEntry, // represents the LIMIT in api 
+  defaultPage,  // represents the OFFSET in api
+  rows,         // total number of entities the slug has.
+  setsRenderer, // offset in the maximumNumberOfPage. default value is zero.  
+  isLoading,
+  EntryValues, // options entry value in dropdown
+  maximumNumberOfPage // maximum number of page displayed
+}) => {
+
+  const limit = rows - setsRenderer * maximumNumberOfPage;
+  const lengthParams = limit > maximumNumberOfPage ? maximumNumberOfPage : limit;
+
+  const setRendererIsZero = setsRenderer === 0;
+  const rightButtonStatus = setsRenderer === Math.floor(rows / maximumNumberOfPage);
+
+  const minPage = 0;
+  const minPageEntry = 0;
+  // left double arrow
+  const prevPageEntry = (setsRenderer - 1) * maximumNumberOfPage;
+  const prevPage = setsRenderer - 1;
+ // left arrow
+
+
+  const maxPage = Math.floor(rows / maximumNumberOfPage);
+  const maxPageEntry = (Math.floor(rows / maximumNumberOfPage) * maximumNumberOfPage);
+ // right double arrow
+
+  const nextPageEntry = (setsRenderer + 1) * maximumNumberOfPage; 
+  const nextPage = setsRenderer + 1;
+// right arrow
+
+
+  const onChangeEntry = (evt) => {
+    dispatch({ type: SET_ENTRIES, payload: evt.target.value });
+  };
+
+  const shiftPage = (page) => {
+    dispatch({ type: SET_PAGE, payload: page });
+  };
+
+  return (
+    <div className="pagination-general">
+      <div>
+        {EntryValues && <select
+          defaultValue={defaultEntry}
+          name="pagination"
+          className="pagination-dropdown"
+          onChange={onChangeEntry}
+        >
+          {EntryValues.map((val,i)=>(
+            <option key={i} value={val}>{val}</option>
+          ))}
+        </select>}
+        <label htmlFor="pagination">Entries per page</label>
+      </div>
+      <div className="pagination-buttons-container">
+        {isLoading && <AppButtonSpinner/>}
+        <button
+          className="page-shift-button-left-double"
+          disabled={setRendererIsZero}
+          onClick={() => {
+            dispatch({
+              type: SET_PAGE,
+              payload: minPageEntry,
+            });
+            dispatch({
+              type: PAGE_SETS_RENDERER,
+              payload: minPage,
+            });
+          }}
+        >
+          <AiOutlineDoubleLeft
+            className="page-shift-icons-double"
+            style={{ height: "1.2em" }}
+          />
+        </button>
+        <button
+          className="page-shift-button-left"
+          disabled={setRendererIsZero}
+          name="page-shift-button-left"
+          onClick={() => {
+            dispatch({
+              type: SET_PAGE,
+              payload: prevPageEntry,
+            });
+            dispatch({
+              type: PAGE_SETS_RENDERER,
+              payload: prevPage,
+            });
+          }}
+        >
+          <MdKeyboardArrowLeft
+            style={{ height: "1.5em" }}
+            className="page-shift-icons"
+          />
+        </button>
+        {rows &&
+          Array.from(
+            { length: lengthParams },
+            (_, i) => (
+              <button
+                className={
+                  Number(defaultPage) !==
+                  (setRendererIsZero ? i : setsRenderer * maximumNumberOfPage + i)
+                    ? "page-number-button"
+                    : "page-number-button active"
+                }
+                key={i}
+                disabled={
+                  Number(defaultPage) ===
+                  (setRendererIsZero ? i : setsRenderer * maximumNumberOfPage + i)
+                }
+                onClick={() =>
+                  shiftPage(
+                    setRendererIsZero ? i : setsRenderer * maximumNumberOfPage + i
+                  )
+                }
+              >
+                <span className="page-number">
+                  {i + maximumNumberOfPage * setsRenderer + 1}
+                </span>
+              </button>
+            )
+          )}
+        <button
+          className="page-shift-button-right"
+          disabled={rightButtonStatus}
+          name="page-shift-button-right"
+          onClick={() => {
+            dispatch({
+              type: SET_PAGE,
+              payload: nextPageEntry,
+            });
+            dispatch({
+              type: PAGE_SETS_RENDERER,
+              payload: nextPage,
+            });
+          }}
+        >
+          <MdKeyboardArrowRight
+            style={{ height: "1.5em" }}
+            className="page-shift-icons"
+          />
+        </button>
+        <button
+          className="page-shift-button-right-double"
+          disabled={rightButtonStatus}
+          onClick={() => {
+            dispatch({
+              type: SET_PAGE,
+              payload: maxPageEntry,
+            });
+            dispatch({
+              type: PAGE_SETS_RENDERER,
+              payload: maxPage,
+            });
+          }}
+        >
+          <AiOutlineDoubleRight
+            className="page-shift-icons-double"
+            style={{ height: "1.2em" }}
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AppContentPagination;

--- a/components/reducers/contentManagerReducer.js
+++ b/components/reducers/contentManagerReducer.js
@@ -6,6 +6,11 @@ import {
   SET_COLUMNS,
   SET_ENTITY_TYPE_NAME,
   SET_ROWS,
+  SET_ENTRIES,
+  SET_PAGE,
+  ROWS_SET,
+  PAGE_SETS_RENDERER,
+  SET_FIRST_FETCH
 } from "@/lib/actions";
 
 export const initialState = {
@@ -13,9 +18,15 @@ export const initialState = {
   columns: [],
   rows: [],
   entity_type_name: null,
-  isLoading: false,
+  isLoading: true,
   isRefresh: true,
+  entry: 10,
+  page: 0,
+  rows:null,
+  setsRenderer:0,
+  firstFetch: true,
 };
+
 
 export const contentManagerReducer = (state, action) => {
   switch (action.type) {
@@ -59,6 +70,31 @@ export const contentManagerReducer = (state, action) => {
       return {
         ...state,
         rows: action.payload,
+      };
+    case SET_ENTRIES:
+      return {
+        ...state,
+        entry: action.payload,
+      };
+    case SET_PAGE:
+      return {
+        ...state,
+        page: action.payload,
+      };
+    case ROWS_SET:
+      return {
+        ...state,
+        page: action.payload,
+      };
+    case PAGE_SETS_RENDERER:
+      return {
+        ...state,
+        setsRenderer: action.payload,
+      };
+    case SET_FIRST_FETCH:
+      return {
+        ...state,
+        firstFetch: action.payload,
       };
   }
 };

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,3 +1,6 @@
 export const SKELETON_FILLER = '_______________';
 export const DEFAULT_SKELETON_ROW_COUNT = 3;
 export const DEFAULT_SKELETON_ROW_TABLE_COUNT = 5;
+export const defaultPageRender = 0;
+export const maximumNumberOfPage = 10;
+export const EntryValues = [10, 20, 30, 40, 50];

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -22,3 +22,9 @@ export const SET_ROWS = "SET_ROWS";
 export const SET_SHOW = "SET_SHOW";
 export const SET_MODAL_CONTENT = "SET_MODAL_CONTENT";
 export const SET_VALIDATE_ALL = "SET_VALIDATE_ALL";
+export const SET_PAGE = "SET_PAGE";
+export const ROWS_SET = "ROWS_SET";
+export const PAGE_SETS_RENDERER = "PAGE_SETS_RENDERER";
+export const SET_FIRST_FETCH = "SET_FIRST_FETCH";
+
+

--- a/pages/api/[entity_type_slug].js
+++ b/pages/api/[entity_type_slug].js
@@ -62,15 +62,15 @@ async function handler(req, res) {
   async function get(req, res) { 
     try{
       const queries = req.query;
-      const { entity_type_slug } = queries;
-      const rawData = await Entity.where({entity_type_slug});
+      const { entity_type_slug, entry, page } = queries;
+      const rawData = await Entity.findByPageAndEntry({ entity_type_slug, entry, page});
       const rawEntityType = await EntityType.find({slug: entity_type_slug});
 
       const initialFormat = {
         indexedData: {}
       };      
 
-      const dataTemp = rawData.reduce((collection, item) => {
+      const dataTemp = rawData.data.reduce((collection, item) => {
         return {
           indexedData: {
             ...collection.indexedData,
@@ -101,8 +101,8 @@ async function handler(req, res) {
             }}
 
           },
-          entity_type_id: item.entity_type_id
-
+          entity_type_id: item.entity_type_id,
+          total_rows: rawData.total_rows
         };
 
       }, initialMetadata);

--- a/styles/klaudsolcms.scss
+++ b/styles/klaudsolcms.scss
@@ -216,7 +216,108 @@
     height: 75vh;
 }
 
+.container-fluid {
+    padding: 0px 40px 0px 40px;
+}
 
+.pagination-general{
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  height: 60px;
+  color: #323C4E;
+
+  .pagination-dropdown{
+
+    width: 60px;
+    height: 28px;
+    outline: #323C4E;
+    margin-right: 6px;
+    padding: 0px 5px 0px 5px;
+    border-radius: 4px;
+    color: #323C4E;
+  }
+
+  .pagination-dropdown::after{
+     transform: rotate(180deg);
+  }
+}
+
+.pagination{
+    font-size: 0.9em;
+
+  }
+
+  .pagination-buttons-container{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #323C4E;
+
+    .page-number-button{
+      display: flex;
+      width: 22px;
+      height: 28px;
+      justify-content: center;
+      align-items: center;
+      outline: none;
+      border-radius: 2px;
+      color: #333b3fe5;
+      border: 1px solid #333b3fe5;
+      margin: 0px 5px 0px 5px;
+
+      &.active{ 
+        border: 1px solid #333b3f8f;
+        color:#333b3f8f;
+        cursor: default;
+      }
+    }
+
+    .page-shift-button-left,  .page-shift-button-right{
+        outline: none;
+        border: none;
+        background: none;
+        padding: 0px;   
+        .page-shift-icons{
+            display: block;
+        }
+        svg{
+            width: 2em;
+            color: #323C4E;          
+        }
+        &:disabled{
+            opacity: 60%;
+        }
+      }
+
+      .page-number{
+        padding: 3px;
+     }
+
+     .page-shift-button-left-double,  .page-shift-button-right-double{
+        outline: none;
+        border: none;
+        background: none;
+        padding: 0px;   
+        .page-shift-icons-double{
+            display: block;
+        }
+        svg{
+            width: 2em;
+            color: #323C4E;   
+
+        }
+        &:disabled{
+            opacity: 60%;
+        }
+      }
+
+      .page-number{
+        padding: 3px;
+     }
+
+  }
 
 .submenu_title {
     color: #455a64 !important;
@@ -621,6 +722,8 @@ $onFocus: #323C4E;
 #table_general_main{
 overflow-x: scroll;
 height: 100%;
+border: 1px solid #b0bec5;
+border-radius: 5px;
 }
 
 #table_general, #table_skeleton {


### PR DESCRIPTION
1. created a customized and reusable Pagination component `<AppContentPagination/>`. The component receives 8 required and 1 optional properties.

![1 pagination](https://user-images.githubusercontent.com/109654448/215252313-8a9a0fd1-864e-458e-bc3c-7fbbdf759757.PNG)
![1-1 pagination props](https://user-images.githubusercontent.com/109654448/215252322-e97172e9-e9e3-4218-b177-af8d503386ad.PNG)

note: default number of entries is temporarily set to 1 in the video in order to show case `next page`, `previous page`, `min page`, and `max page` functionality. The default number of entries is set to 10 in PR repository.


https://user-images.githubusercontent.com/109654448/215252353-856a9fa7-c6fc-420a-b356-1d6baa7fa693.mp4

2. refactored backend queries and added limit and offset as the function's parameters.

![2 refactored backend](https://user-images.githubusercontent.com/109654448/215252368-d6b77887-541e-4764-a43f-5dcdd78dfcec.PNG)

3. only show the skeleton table in the first load.

![3 skeleton](https://user-images.githubusercontent.com/109654448/215252382-ec16e747-b4e3-4feb-a25d-5c4e91233856.PNG)

4. abort all previous api request when the user moves to another page or different slug to avoid flickering of all requested data as shown in the video below.

WITHOUT ABORT CONTROLLER

https://user-images.githubusercontent.com/109654448/215252420-b32f613e-efef-4fdf-888a-2488da118239.mp4

WITH ABORT CONTROLLER


https://user-images.githubusercontent.com/109654448/215252437-4c959405-e5fc-4668-989c-3226c1a34ee4.mp4

application of code (abort)


![4 abort](https://user-images.githubusercontent.com/109654448/215252475-6107c301-eab3-4eef-9e07-4c21f19b6a0f.PNG)

![4-2 abort](https://user-images.githubusercontent.com/109654448/215252482-67f266c6-8d89-4ee1-8558-521d9fa386cd.PNG)

5. created a separate file for const variables and reducer.

