### PR TITLE
[no ticket] fix-image-update-is-not-working-when-new-content-type-is-created

### DIFF
--- a/backend/data_access/S3.js
+++ b/backend/data_access/S3.js
@@ -123,9 +123,11 @@ export const addFilesToBucket = async (files) => {
 // We also need a function to update one file. This function updates
 // multiple files
 export const updateFilesFromBucket = async (file, body, toDelete) => {
-  const paramsForDeletion = generateS3ParamsForDeletion(toDelete);
-  await deleteFilesFromBucket(paramsForDeletion);
+  if(toDelete?.length){
+    const paramsForDeletion = generateS3ParamsForDeletion(toDelete);
+    await deleteFilesFromBucket(paramsForDeletion);
+  }
   const uploadedFile = await addFilesToBucket(file, body);
-
+  
   return uploadedFile;
 };

--- a/pages/admin/content-manager/[entity_type_slug]/[id].js
+++ b/pages/admin/content-manager/[entity_type_slug]/[id].js
@@ -145,8 +145,8 @@ export default function Type({ cache }) {
 
   const getS3Keys = (files) => {
     const fileKeys = Object.keys(files);
-    const s3Keys = fileKeys.map((file) => state.values[file].key);
-
+    const s3Keys = fileKeys.filter((file) => state.values[file].key);
+    
     return s3Keys;
   };
 

--- a/pages/admin/content-manager/[entity_type_slug]/[id].js
+++ b/pages/admin/content-manager/[entity_type_slug]/[id].js
@@ -145,7 +145,7 @@ export default function Type({ cache }) {
 
   const getS3Keys = (files) => {
     const fileKeys = Object.keys(files);
-    const s3Keys = fileKeys.filter((file) => state.values[file].key);
+    const s3Keys = fileKeys.filter(file => state.values[file].key);
     
     return s3Keys;
   };

--- a/pages/api/[entity_type_slug]/[id].js
+++ b/pages/api/[entity_type_slug]/[id].js
@@ -163,7 +163,7 @@ async function update(req, res) {
       JSON.stringify(bodyRaw)
     );
     const { toDeleteRaw, ...body } = entriesRaw;
-    const toDelete = toDeleteRaw.split(",");
+    const toDelete = toDeleteRaw ? toDeleteRaw.split(",") : []
 
     if (files.length > 0) {
       const resFromS3 = await updateFilesFromBucket(files, body, toDelete);


### PR DESCRIPTION
1. When updating an image using the PUT method, the `toDeleteRaw` value (e.g., 12323_meow.png) is sent to delete the existing image before creating a new one. However, if a new content-type image is created, the entry will be empty when updating, which makes the `toDeleteRaw` value undefined. Therefore, deletion should only occur if the `toDeleteRaw` value exists.