### PR TITLE
[KlaudSol-CMS-#157] Redirect from login page to dashboard if session is still alive

### DIFF
--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -28,6 +28,7 @@ async function loginHandler(req, res) {
       lastName,
       role,
       defaultEntityType,
+      homepage: `/admin/content-manager/${defaultEntityType}`
     }; 
     await req.session.save();    
     res.status(200).json({message: "OK"});

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -28,7 +28,7 @@ async function loginHandler(req, res) {
       lastName,
       role,
       defaultEntityType,
-      homepage: `/admin/content-manager/${defaultEntityType}`
+      homepage: '/admin'
     }; 
     await req.session.save();    
     res.status(200).json({message: "OK"});


### PR DESCRIPTION
1. added the forgotten `homepage: '/admin/content-manager/${defaultEntityType}'` in the api login for homepage redirection.