### PR TITLE
Add plugins folder on migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ pages/api/plugins/*
 
 # klaudsol migrations
 db/migrations/plugins/*
+!db/migrations/plugins/README.md
 !db/migrations/plugins/.keep
 
 

--- a/components/elements/inner/sidebar/FullSidebar.js
+++ b/components/elements/inner/sidebar/FullSidebar.js
@@ -98,3 +98,4 @@ const FullSidebar = ({sidebarButtons, firstName, lastName, defaultEntityType, ro
 }
 
 export default React.memo(FullSidebar)
+

--- a/components/elements/inner/sidebar/FullSidebar.js
+++ b/components/elements/inner/sidebar/FullSidebar.js
@@ -98,4 +98,3 @@ const FullSidebar = ({sidebarButtons, firstName, lastName, defaultEntityType, ro
 }
 
 export default React.memo(FullSidebar)
-

--- a/db/migrations/plugins/README.md
+++ b/db/migrations/plugins/README.md
@@ -1,0 +1,3 @@
+This directory stores all KlaudSol CMS plugins. 
+
+This directory is being ignored by Git.


### PR DESCRIPTION
We are unable to migrate the DB stuff for the plugins because the `plugins` folder is missing.