### PR TITLE
Temporarily comment out validate on renderers

### DIFF
--- a/components/renderers/admin/FloatRenderer.js
+++ b/components/renderers/admin/FloatRenderer.js
@@ -16,7 +16,7 @@ const FloatRenderer = ({
       name={name}
       className={cx("general-input-text", 
       {"general-input-error" : errors[name] && touched[name]})}
-      validate={(v) => TypesValidator(v, type)}
+      //validate={(v) => TypesValidator(v, type)}
       disabled={disabled}
     />
     <ErrorRenderer 

--- a/components/renderers/admin/GalleryRenderer.js
+++ b/components/renderers/admin/GalleryRenderer.js
@@ -19,7 +19,7 @@ const GalleryRenderer = ({
             accept={accept}
             name={name}
             className={cx("input_text mb-2", className)}
-            validate={(v) => TypesValidator(v, type)}
+            //validate={(v) => TypesValidator(v, type)}
             style={
                 !isErrorDisabled && errors[name] && touched[name]
                     ? { borderColor: "red", outlineColor: "red" }

--- a/components/renderers/admin/TextAreaRenderer.js
+++ b/components/renderers/admin/TextAreaRenderer.js
@@ -14,7 +14,7 @@ const TextAreaRenderer = ({
     <Field
       type="textarea"
       name={name}
-      validate={(v) => TypesValidator(v, type)}
+      //validate={(v) => TypesValidator(v, type)}
     >
       {({ field }) => (
         <textarea

--- a/components/renderers/admin/TextRenderer.js
+++ b/components/renderers/admin/TextRenderer.js
@@ -11,7 +11,7 @@ const TextRenderer = ({ className, name, type, errors, touched, disabled, option
       className={cx("general-input-text", {
         "general-input-error": errors[name] && touched[name],
       })}
-      validate={optional ? null : (v) => TypesValidator(v, type)}
+      //validate={optional ? null : (v) => TypesValidator(v, type)}
       disabled={disabled}
     />
     {!optional && <ErrorRenderer name={name} errors={errors} touched={touched} />}

--- a/components/renderers/admin/UploadRenderer.js
+++ b/components/renderers/admin/UploadRenderer.js
@@ -19,7 +19,7 @@ const UploadRenderer = ({
       accept={accept}
       name={name}
       className={cx("input_text mb-2", className)}
-      validate={(v) => TypesValidator(v, type)}
+      //validate={(v) => TypesValidator(v, type)}
       style={
         !isErrorDisabled && errors[name] && touched[name]
           ? { borderColor: "red", outlineColor: "red" }


### PR DESCRIPTION
Temporarily commented out validate on the following: 
- Text Renderers
- Textarea Renderers
- Float Renderers
- Gallery Renderer
- Upload Renderer

Note: Only slug field is required.
<img width="1194" alt="Screenshot 2023-06-02 at 9 19 55 AM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/304b8158-ffc6-4f81-8749-7063a96cfd14">
