### PR TITLE
Add Rich Text Attribute type

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,15 @@ nvm use --lts
 
 ## Screenshots
 
+Screnshots: https://cms.demo.klaudsol.app
+
 <img width="1678" alt="image" src="https://user-images.githubusercontent.com/1546228/192326061-794fcf32-c89a-4604-9bf2-a6b2ccf09ab2.png">
-
-<img width="1678" alt="image" src="https://user-images.githubusercontent.com/1546228/192326373-d30303b2-4988-4282-8fdc-70d9a0fa190c.png">
-
-<img width="1679" alt="image" src="https://user-images.githubusercontent.com/1546228/196386299-7c82a22d-aeae-439c-a62f-725bb20a1358.png">
-
-<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1546228/196386361-76cbfddb-5d7b-45d4-aeb2-c807e477fe02.png">
+<img width="1678" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/5fc4c908-4734-417d-a928-fd931d4eef31">
+<img width="1677" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/de115d88-e86e-4776-82d0-abcc2786ea3c">
+<img width="1678" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/9836b2b3-d006-4124-9fe8-5521eb6a2433">
 
 
-<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1546228/196385953-a8ced339-a37e-4601-bd3a-f2e4e85bef96.png">
 
-<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1546228/196386024-caa4e99b-3e76-457b-a5e9-f4b760494196.png">
+
 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Screnshots: https://cms.demo.klaudsol.app
 <img width="1677" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/2360a358-7e58-4717-8d71-47b93b7f22be">
 <img width="1678" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/5fc4c908-4734-417d-a928-fd931d4eef31">
 <img width="1677" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/de115d88-e86e-4776-82d0-abcc2786ea3c">
+<img width="1679" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/310f4204-d086-4dbf-89bd-f96a2d9cbe0d">
 <img width="1678" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/9836b2b3-d006-4124-9fe8-5521eb6a2433">
 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ nvm use --lts
 
 Screnshots: https://cms.demo.klaudsol.app
 
-<img width="1678" alt="image" src="https://user-images.githubusercontent.com/1546228/192326061-794fcf32-c89a-4604-9bf2-a6b2ccf09ab2.png">
+<img width="1677" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/2360a358-7e58-4717-8d71-47b93b7f22be">
 <img width="1678" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/5fc4c908-4734-417d-a928-fd931d4eef31">
 <img width="1677" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/de115d88-e86e-4776-82d0-abcc2786ea3c">
 <img width="1678" alt="image" src="https://github.com/klaudsol/klaudsol-cms/assets/1546228/9836b2b3-d006-4124-9fe8-5521eb6a2433">

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 * Added Video attribute type
 * Added Custom Attribute types feature via plugins.
 * Can now use exported classes of plugins using the `plugin()` function
+* Added Singleton variant for Content Type.
 * Added Rich Text Attribute type
 
 # 3.5.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 * Added Video attribute type
 * Added Custom Attribute types feature via plugins.
 * Can now use exported classes of plugins using the `plugin()` function
+* Added Rich Text Attribute type
 
 # 3.5.1
 * Removed fields validation for now, will roll-out a more robust field validation mechanism in the future.

--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -231,6 +231,7 @@ class Entity {
             value:
               attributeType == "textarea" ||
               attributeType === "gallery" ||
+              attributeType === "rich-text" ||
               attributeType == "custom"
                 ? { stringValue: entry[attributeName] }
                 : { isNull: true },
@@ -337,6 +338,7 @@ class Entity {
             value:
               (attributeType == "textarea" ||
                 attributeType === "gallery" ||
+                attributeType === "rich-text" ||
                 attributeType === "custom") && 
               entries[attributeName]
                 ? { stringValue: entries[attributeName] }

--- a/components/EntityAttributeValue.js
+++ b/components/EntityAttributeValue.js
@@ -21,6 +21,8 @@ const formatImage = (key) => {
         return item.value_boolean;
       case 'textarea':
         return item.value_long_string;
+      case 'rich-text':
+        return item.value_long_string;
       case 'image':
         if(!item.value_string) return;
         const imageValues = formatImage(item.value_string);

--- a/components/attribute_types/AttributeType.js
+++ b/components/attribute_types/AttributeType.js
@@ -11,6 +11,7 @@ export default class AttributeType {
 
     static TEXT_CMS_TYPE = 'text';
     static TEXTAREA_CMS_TYPE = 'textarea';
+    static RICH_TEXT_CMS_TYPE = 'rich-text';
     static CUSTOM = 'custom';
 
 

--- a/components/attribute_types/AttributeTypeFactory.js
+++ b/components/attribute_types/AttributeTypeFactory.js
@@ -3,23 +3,22 @@ import TextAttributeType from "@/components/attribute_types/TextAttributeType";
 import TextareaAttributeType from "@/components/attribute_types/TextareaAttributeType";
 import LegacyAttributeType from '@/components/attribute_types/LegacyAttributeType';
 import { plugin } from '@/components/plugin/plugin';
+import RichTextAttributeType from '@/components/attribute_types/RichTextAttributeType';
 
 export default class AttributeTypeFactory {
-
-    static create({data, metadata}) {
-
-      switch(metadata?.type) {
-
-        case AttributeType.TEXT_CMS_TYPE:
-          return new TextAttributeType({data, metadata});
-        case AttributeType.TEXTAREA_CMS_TYPE:
-          return new TextareaAttributeType({data, metadata});
-        case AttributeType.CUSTOM:
-          const CustomAttributeType = plugin(metadata.custom_name);
-          return new CustomAttributeType({data, metadata});
-        default:
-          return new LegacyAttributeType({data, metadata});;
-
-      }
+  static create({data, metadata}) {
+    switch(metadata?.type) {
+      case AttributeType.TEXT_CMS_TYPE:
+        return new TextAttributeType({data, metadata});
+      case AttributeType.TEXTAREA_CMS_TYPE:
+        return new TextareaAttributeType({data, metadata});
+      case AttributeType.RICH_TEXT_CMS_TYPE:
+        return new RichTextAttributeType({data, metadata});
+      case AttributeType.CUSTOM:
+        const CustomAttributeType = plugin(metadata.custom_name);
+        return new CustomAttributeType({data, metadata});
+      default:
+        return new LegacyAttributeType({data, metadata});;
     }
+  }
 }

--- a/components/attribute_types/LegacyAttributeType.js
+++ b/components/attribute_types/LegacyAttributeType.js
@@ -9,14 +9,12 @@ const LegacyAttributeReadOnlyComponent = ({text}) => {
         <>{text}</>
     );
 }
-
-
   //TODO: Refactor
   const formatSpecialDataTypes = (data) => {
     if (Array.isArray(data)) return `${data.length} item/s`; // Checks if its an attribute w/ multiple values
     else if (typeof data === "object" && data?.link) return data?.name; // Checks if its an image
     else if (typeof data === "object") return JSON.stringify(data); //Unsupported object. Will need to do this until the OOP solution becomes available.
-    else if (typeof data === "boolean") return entry[accessor] ? "Yes" : "No"
+    else if (typeof data === "boolean") return data ? "Yes" : "No"
 
     return data;
   };

--- a/components/attribute_types/RichTextAttributeType.js
+++ b/components/attribute_types/RichTextAttributeType.js
@@ -1,0 +1,77 @@
+import AttributeType from '@/components/attribute_types/AttributeType';
+import { useFormikContext, useField } from "formik";
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
+import 'react-quill/dist/quill.snow.css';
+
+const RichTextAttributeReadOnlyComponent = ({text}) => {
+  // TODO: Refactor this to lib
+  const MAX_STRING_LENGTH = 50;
+
+  const truncate = (string)  => {
+    return (string?.length && string.length > MAX_STRING_LENGTH) ? `${string.slice(0, MAX_STRING_LENGTH)}...` : string;   
+  }
+
+  // Get the text inside the html elements
+  const extractTextFromHTML = (html) => {
+    const parser = new DOMParser();
+    const parsedDoc = parser.parseFromString(html, 'text/html');
+    return parsedDoc.body.textContent;
+  };
+
+  return (
+    <>{truncate(extractTextFromHTML(text))}</>
+  );
+}
+
+const RichTextEditableComponent = ({name, errors}) => {
+  const { setFieldValue, setTouched, touched, values } = useFormikContext();
+  const [{value}] = useField(name); 
+  // sets the initial content of the editor state
+  const initialContent = value ? value : null; // Initial HTML content
+  const [editorState, setEditorState] = useState(initialContent);
+  
+  // Gets the HTML value from the editor and passes it to the formik field
+  const handleConvertToHTML = (e) => {
+    setEditorState(e);
+    setFieldValue(name, e);
+  };
+
+  // Set the toolbar options
+  const toolbarOptions = [
+    [{ header: [1, 2, 3, 4, 5, 6] }], // header options
+    ['bold', 'italic', 'underline', 'strike'], // inline formatting options
+    [{ list: 'ordered' }, { list: 'bullet' }], // list options
+  ];
+
+  // Set the styles 
+  const editorStyles = { 
+    height: '200px', 
+    marginBottom: '50px', 
+    height: '300px'
+  }
+  
+  return (
+    <>
+      <ReactQuill
+        theme="snow"
+        value={editorState}
+        onChange={handleConvertToHTML}
+        style={editorStyles}
+        modules={{ toolbar: toolbarOptions }}
+      />
+    </>
+  );
+};
+
+export default class RichTextAttributeType extends AttributeType {
+  readOnlyComponent(){
+    return RichTextAttributeReadOnlyComponent; 
+  }
+  
+  editableComponent(){
+    return RichTextEditableComponent;
+  }
+}

--- a/components/cmsTypes.js
+++ b/components/cmsTypes.js
@@ -12,7 +12,8 @@ export const CMS_TYPES = {
   // the AdminRenderer component can function properly
   PASSWORD: "password",
   CHECKBOX: "checkbox",
-  CUSTOM: "custom"
+  CUSTOM: "custom",
+  RICH_TEXT: "rich-text"
 };
 
 // resources types

--- a/components/renderers/admin/AdminRenderer.js
+++ b/components/renderers/admin/AdminRenderer.js
@@ -10,6 +10,7 @@ import { validImageTypes, validVideoTypes } from "@/lib/Constants";
 import VideoRenderer from "./VideoRenderer";
 import BooleanRenderer from "./BooleanRenderer";
 import { plugin } from "@/components/plugin/plugin";
+import RichTextAttributeType from "@/components/attribute_types/RichTextAttributeType";
 
 const AdminRenderer = ({ type, ...params }) => {
   switch (type) {
@@ -32,6 +33,10 @@ const AdminRenderer = ({ type, ...params }) => {
       return <VideoRenderer accept={validVideoTypes} {...params} />;
     case CMS_TYPES.BOOLEAN:
       return <BooleanRenderer type={type} {...params} title="Yes" />;
+    case CMS_TYPES.RICH_TEXT:
+      const richTextAttributeType = new RichTextAttributeType();
+      const RichTextComponent =  richTextAttributeType.editableComponent();
+      return <RichTextComponent {...params} {...richTextAttributeType.props()} />;
     case CMS_TYPES.CUSTOM:
       const CustomAttributeType = plugin(params.customName);
       const customAttributeType = new CustomAttributeType();

--- a/components/renderers/admin/AdminRenderer.js
+++ b/components/renderers/admin/AdminRenderer.js
@@ -11,6 +11,7 @@ import VideoRenderer from "./VideoRenderer";
 import BooleanRenderer from "./BooleanRenderer";
 import { plugin } from "@/components/plugin/plugin";
 import RichTextAttributeType from "@/components/attribute_types/RichTextAttributeType";
+import AttributeTypeFactory from "@/components/attribute_types/AttributeTypeFactory";
 
 const AdminRenderer = ({ type, ...params }) => {
   switch (type) {
@@ -34,9 +35,9 @@ const AdminRenderer = ({ type, ...params }) => {
     case CMS_TYPES.BOOLEAN:
       return <BooleanRenderer type={type} {...params} title="Yes" />;
     case CMS_TYPES.RICH_TEXT:
-      const richTextAttributeType = new RichTextAttributeType();
-      const RichTextComponent =  richTextAttributeType.editableComponent();
-      return <RichTextComponent {...params} {...richTextAttributeType.props()} />;
+      const attributeType = AttributeTypeFactory.create({metadata: {type, custom_name: params.customName}});
+      const Component =  attributeType.editableComponent();
+      return <Component {...params} {...attributeType.props()} />;
     case CMS_TYPES.CUSTOM:
       const CustomAttributeType = plugin(params.customName);
       const customAttributeType = new CustomAttributeType();

--- a/constants/index.js
+++ b/constants/index.js
@@ -1,6 +1,7 @@
 export const inputValues = [
   { value: "text", option: "Text" },
   { value: "textarea", option: "Text Area" },
+  { value: "rich-text", option: "Rich Text" },
   { value: "link", option: "Link" },
   { value: "image", option: "Image" },
   { value: "gallery", option: "Gallery" },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-live-clock": "^5.8.1",
     "react-moment": "^1.1.2",
     "react-portal-overlay": "^1.1.0",
+    "react-quill": "^2.0.0",
     "react-redux": "^7.2.5",
     "react-select": "^5.3.2",
     "reactstrap": "^9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,6 +1682,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/quill@^1.3.10":
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.10.tgz#dc1f7b6587f7ee94bdf5291bc92289f6f0497613"
+  integrity sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==
+  dependencies:
+    parchment "^1.1.2"
+
 "@types/raf@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@types/raf/-/raf-3.4.0.tgz#2b72cbd55405e071f1c4d29992638e022b20acc2"
@@ -2219,6 +2226,11 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -2466,6 +2478,18 @@ debug@^4.0.1, debug@^4.1.1, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+deep-equal@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
 
 deep-equal@^2.0.5:
   version "2.2.0"
@@ -2934,15 +2958,30 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+  integrity sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==
 
 fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
@@ -3482,7 +3521,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-regex@^1.1.4:
+is-regex@^1.0.4, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -3738,7 +3777,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.21:
+lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3927,7 +3966,7 @@ object-inspect@^1.12.3, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
-object-is@^1.1.5:
+object-is@^1.0.1, object-is@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
   integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
@@ -4017,6 +4056,11 @@ pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+parchment@^1.1.2, parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+  integrity sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -4168,6 +4212,27 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quill-delta@^3.6.2:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.3.tgz#b19fd2b89412301c60e1ff213d8d860eac0f1032"
+  integrity sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.2"
+    fast-diff "1.1.2"
+
+quill@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
+  integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.2"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -4316,6 +4381,15 @@ react-portal@^4.2.1:
   dependencies:
     prop-types "^15.5.8"
 
+react-quill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-2.0.0.tgz#67a0100f58f96a246af240c9fa6841b363b3e017"
+  integrity sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==
+  dependencies:
+    "@types/quill" "^1.3.10"
+    lodash "^4.17.4"
+    quill "^1.3.7"
+
 react-redux@^7.2.5:
   version "7.2.9"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
@@ -4404,7 +4478,7 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-regexp.prototype.flags@^1.4.3:
+regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.4.3:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
   integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==


### PR DESCRIPTION
- Added Rich Text Attribute Type
- Used `react-quill` library for the wysiwyg editor
- Current toolbar has the ff:
   - Headings (h1 to h6)
   - Bold, italic, underline and strike through
   - Ordered and unordered list

This is the sample UI when editing the Rich Text Attribute Type
<img width="1512" alt="Screenshot 2023-06-22 at 1 03 03 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/1c317dfc-5a5c-4295-9dd3-4e787ab15f32">

This is the sample UI when viewing the table
<img width="1512" alt="Screenshot 2023-06-22 at 1 03 58 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/27b61294-0ce6-4f82-9809-d4284cd704cc">

This is the sample API
<img width="1507" alt="Screenshot 2023-06-22 at 1 02 40 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/4837c20d-4d51-4444-bb06-35252b005405">

