### PR TITLE
Fixed empty galleries when editing

### DIFF
--- a/components/EntityAttributeValue.js
+++ b/components/EntityAttributeValue.js
@@ -31,7 +31,7 @@ const formatImage = (key) => {
         const videoValues = formatImage(item.value_string);
         return videoValues;
       case 'gallery':
-        if(!item.value_long_string) return;
+        if(!item.value_long_string) return [];
 
         const galleryValuesRaw = JSON.parse(item.value_long_string);
         const galleryValues = galleryValuesRaw.map((item) => formatImage(item));


### PR DESCRIPTION
- Whenever we add a new gallery attribute to an existing content type, their value/s will be `null`
- This will make the program explode