### PR TITLE
Add File Attribute Type

### DIFF
--- a/backend/models/core/Entity.js
+++ b/backend/models/core/Entity.js
@@ -228,7 +228,8 @@ class Entity {
               attributeType == "text" ||
               attributeType == "image" ||
               attributeType == "link" ||
-              attributeType === "video"
+              attributeType === "video" ||
+              attributeType == "file" 
                 ? { stringValue: entry[attributeName] }
                 : { isNull: true },
           },
@@ -419,6 +420,7 @@ class Entity {
               (attributeType == "text" ||
                 attributeType == "image" ||
                 attributeType == "video" ||
+                attributeType == "file" ||
                 attributeType == "link") &&
               entries[attributeName]
                 ? { stringValue: entries[attributeName] }

--- a/components/EntityAttributeValue.js
+++ b/components/EntityAttributeValue.js
@@ -32,6 +32,11 @@ const formatImage = (key) => {
         if(!item.value_string) return;
         const videoValues = formatImage(item.value_string);
         return videoValues;
+
+     case 'file':
+          if(!item.value_string) return;
+          const fileValues = formatImage(item.value_string);
+          return fileValues;
       case 'gallery':
         if(!item.value_long_string) return [];
 

--- a/components/attribute_types/AttributeType.js
+++ b/components/attribute_types/AttributeType.js
@@ -12,6 +12,7 @@ export default class AttributeType {
     static TEXT_CMS_TYPE = 'text';
     static TEXTAREA_CMS_TYPE = 'textarea';
     static RICH_TEXT_CMS_TYPE = 'rich-text';
+    static FILE_CMS_TYPE = 'file';
     static CUSTOM = 'custom';
 
 

--- a/components/attribute_types/AttributeTypeFactory.js
+++ b/components/attribute_types/AttributeTypeFactory.js
@@ -4,6 +4,7 @@ import TextareaAttributeType from "@/components/attribute_types/TextareaAttribut
 import LegacyAttributeType from '@/components/attribute_types/LegacyAttributeType';
 import { plugin } from '@/components/plugin/plugin';
 import RichTextAttributeType from '@/components/attribute_types/RichTextAttributeType';
+import FileAtrributeType from './FileAttributeType';
 
 export default class AttributeTypeFactory {
   static create({data, metadata}) {
@@ -14,6 +15,8 @@ export default class AttributeTypeFactory {
         return new TextareaAttributeType({data, metadata});
       case AttributeType.RICH_TEXT_CMS_TYPE:
         return new RichTextAttributeType({data, metadata});
+      case AttributeType.FILE_CMS_TYPE:
+        return new FileAtrributeType({data, metadata});
       case AttributeType.CUSTOM:
         const CustomAttributeType = plugin(metadata.custom_name);
         return new CustomAttributeType({data, metadata});

--- a/components/attribute_types/FileAttributeType.js
+++ b/components/attribute_types/FileAttributeType.js
@@ -1,0 +1,75 @@
+import AttributeType from '@/components/attribute_types/AttributeType';
+import { validFileTypes } from '@/lib/Constants';
+import { useFormikContext, useField } from "formik";
+import Link from 'next/link';
+import { useState } from 'react';
+import { AiOutlineFilePdf, AiOutlineFileText, AiOutlineFileWord } from 'react-icons/ai';
+import { FaDownload, FaFile } from 'react-icons/fa';
+import path from 'path';
+
+const getFileType = (filePath) => {
+    const fileExtension = path.extname(filePath);
+    return fileExtension.toLowerCase();
+  }
+
+const FileAttributeReadOnlyComponent = ({text}) => {
+  // TODO: Refactor this to lib
+  const MAX_STRING_LENGTH = 50;
+
+  const truncate = (string)  => {
+    return (string?.length && string.length > MAX_STRING_LENGTH) ? `${string.slice(0, MAX_STRING_LENGTH)}...` : string;   
+  }
+
+  return (
+    <>{truncate(text?.name)}</>
+  );
+}
+
+const FileEditableComponent = ({name, errors}) => {
+  const { setFieldValue, setTouched, touched, values } = useFormikContext();
+  const [{value}] = useField(name); 
+
+  const selectedFileType = value?.name ? getFileType(value.name) : null;
+  const [fileName, setFileName] = useState(value?.name ?? null);
+  const [fileType, setFileType] = useState(selectedFileType);
+
+  const setFileValue = (e) => {
+    const file = e.target.files[0];
+    if(!file) return
+    setFileName(e.target.files[0].name);
+    setFileType(e.target.files[0].type);
+    setFieldValue(name, file);
+  };
+
+  return (
+    <div className='general-file-col'> 
+       <input
+          accept={validFileTypes}
+          type="file"
+          onChange={setFileValue}
+          id="fileAttributeType"
+          hidden="hidden"
+        />
+        
+        <label htmlFor='fileAttributeType'  className='general-file-row'>
+          <div className='general-file-label'>{fileName ? fileName : 'No file chosen'}</div>
+          <div className='general-file-button'>Browse</div>
+        </label>
+        {value && value.link && 
+        <div className='general-file'>
+          {fileType === '.docx' ? <AiOutlineFileWord className='general-file-icon'/> : fileType === '.pdf' ? <AiOutlineFilePdf className='general-file-icon'/> : <AiOutlineFileText className='general-file-icon'/> }
+          <Link href={value?.link} className='general-file-button-download'><><FaDownload /><div className='general-file-name'>{value.name}</div></></Link>
+        </div>}
+    </div>
+  );
+};
+
+export default class FileAtrributeType extends AttributeType {
+  readOnlyComponent(){
+    return FileAttributeReadOnlyComponent; 
+  }
+  
+  editableComponent(){
+    return FileEditableComponent;
+  }
+}

--- a/components/cmsTypes.js
+++ b/components/cmsTypes.js
@@ -13,7 +13,8 @@ export const CMS_TYPES = {
   PASSWORD: "password",
   CHECKBOX: "checkbox",
   CUSTOM: "custom",
-  RICH_TEXT: "rich-text"
+  RICH_TEXT: "rich-text",
+  FILE: "file"
 };
 
 // resources types

--- a/components/renderers/admin/AdminRenderer.js
+++ b/components/renderers/admin/AdminRenderer.js
@@ -35,6 +35,7 @@ const AdminRenderer = ({ type, ...params }) => {
     case CMS_TYPES.BOOLEAN:
       return <BooleanRenderer type={type} {...params} title="Yes" />;
     case CMS_TYPES.RICH_TEXT:
+    case CMS_TYPES.FILE:
     case CMS_TYPES.CUSTOM:
       const attributeType = AttributeTypeFactory.create({metadata: {type, custom_name: params.customName, id: params.id}});
       const Component =  attributeType.editableComponent();

--- a/constants/index.js
+++ b/constants/index.js
@@ -8,6 +8,7 @@ export const inputValues = [
   { value: "float", option: "Number" },
   { value: "video", option: "Video" },
   { value: "boolean", option: "Boolean" },
+  { value: "file", option: "File" },
   { value: "custom", option: "Custom" }
 ];
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -6,6 +6,7 @@ export const maximumNumberOfPage = 10;
 export const EntryValues = [10, 20, 30, 40, 50];
 export const validImageTypes = "image/png, image/gif, image/jpeg, image/jfif,image/svg+xml";
 export const validVideoTypes = "video/mp4";
+export const validFileTypes = ".pdf, .doc, .docx";
 
 // capabilities 
 export const readContents = 'read_contents';

--- a/styles/general.scss
+++ b/styles/general.scss
@@ -8,6 +8,80 @@
 **/
 
 .general {
+  // File upload 
+  &-file {
+    @include flex(center, center, column);
+    padding-top: 20px;
+    gap: 20px;
+    background-color: transparent;
+    border: 1px solid lightgray;
+    border-radius: 5px;
+    width: 200px;
+    max-width: 200px;
+    min-width: 200px;
+
+    &-icon {
+      color: #455a64;
+      font-size: 75px;
+    }
+
+    &-row {
+      @include flex(flex-start, center, row);
+      width: 100%;
+    }
+
+    &-label {
+      @include padding-tb-lr(10px, 10px);
+      @include font-regular(12px);
+      border: 1px solid lightgray;
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px;
+      width: 100%;
+    }
+
+    &-col {
+      @include flex(flex-start, flex-start, column);
+      gap: 10px;
+    }
+
+    &-name {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 150px;
+      max-width: 150px;
+      width: 150px;
+    }
+
+    &-button {
+      @include font-semi-bold(12px);
+      @include padding-tb-lr(10px, 15px);
+      background-color: #455a64;
+      color: white;
+      border: 1px solid #455a64;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px;
+
+      &-download {
+        @include padding-tb-lr(10px, 5px);
+        @include font-semi-bold(12px);
+        @include flex(center, center, row);
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border: 1px solid #455a64;
+        gap: 5px;
+        color: white;
+        text-decoration: none;
+        width: 100%;
+        background-color: #455a64;
+
+        &:hover {
+          color: white;
+          background-color: #467286;
+        }
+      }
+    }
+  }
   // Text
   &-text {
     @include font-semi-bold(12px);


### PR DESCRIPTION
Added File Attribute Type to CMS
  -- Users may now upload files to CMS (As of now, it only accepts '.pdf', '.docx' and '.doc')
  -- Uploaded files may be downloaded (If you view the entry)
  -- User may change / update the file
  -- Works on Collection Types and Singleton

- New dropdown option - File 
<img width="927" alt="Screenshot 2023-07-18 at 5 55 31 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/dc746150-f304-4a7b-afe3-c32481059ccf">

- Initial UI if no file is chosen yet:
<img width="1510" alt="Screenshot 2023-07-18 at 5 57 30 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/fa5ac0a2-b9c2-4912-9586-2cdc1aacefe3">

- UI if file has been selected
<img width="1471" alt="Screenshot 2023-07-18 at 5 58 27 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/6bafc7d3-71f2-4b23-9a81-5607c3c6da06">

- Table UI sample
<img width="1512" alt="Screenshot 2023-07-18 at 5 48 53 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/cd4fc5c3-9949-44c6-a7df-629982d39e56">

- If user wants to view the entry 
-- PDF FILE
<img width="1512" alt="Screenshot 2023-07-18 at 5 43 28 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/53bfb76e-e03a-4cfb-a7a6-ebddbb47a8c7">

-- .docx FILE
<img width="1512" alt="Screenshot 2023-07-18 at 5 43 42 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/715fb104-a8e3-4a1a-a354-4d58a48fdcfa">
