### PR TITLE
Update rich text

### DIFF
--- a/components/attribute_types/RichTextAttributeType.js
+++ b/components/attribute_types/RichTextAttributeType.js
@@ -41,10 +41,12 @@ const RichTextEditableComponent = ({name, errors}) => {
 
   // Set the toolbar options
   const toolbarOptions = [
-    [{ header: [1, 2, 3, 4, 5, 6] }], // header options
+    [{ header: [1, 2, 3, 4, 5, 6, false] }], // header options
     ['bold', 'italic', 'underline', 'strike'], // inline formatting options
     [{ list: 'ordered' }, { list: 'bullet' }], // list options
     ['link'], // link option
+    [{ 'color': [] }, { 'background': [] }],
+    ['undo', 'redo'],
   ];
 
   // Set the styles 


### PR DESCRIPTION
Added the following to `Rich text` attribute type:

- Normal heading (this is the `<p>` tag)
- Color
- Highlight

<img width="1508" alt="Screenshot 2023-08-02 at 8 24 23 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/93ff329c-5740-40f9-bf37-96c0776981b7">
<img width="1502" alt="Screenshot 2023-08-02 at 8 19 53 PM" src="https://github.com/klaudsol/klaudsol-cms/assets/101687552/2e19c617-450c-4060-8fd2-0ccfe2fe7c01">
